### PR TITLE
60 footer   update title to 2026

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -23,11 +23,8 @@ import Socials from './Socials.astro';
     Devfest 2025
   </a>
 
-  <!--todo: LINK TO BE UPDATED 
-  https://sessionize.com/devfest-aranjuez-2025/
-  -->
   <a
-    href=""
+    href="https://sessionize.com/devfest-aranjuez-2026/"
     target="_blank"
     rel="noopener noreferrer"
     class="mb-3 block text-center"

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -16,12 +16,12 @@ import Socials from './Socials.astro';
 
   <!-- Call for Papers -->
   <a
-    href="https://devfest-2024-aranjuez.vercel.app/"
+    href="devfest2025.gdgaranjuez.com"
     target="_blank"
     rel="noopener noreferrer"
     class="mb-3 block text-center"
   >
-    Devfest2024
+    Devfest2025
   </a>
   <a
     href="https://sessionize.com/devfest-aranjuez-2025/"
@@ -41,6 +41,6 @@ import Socials from './Socials.astro';
   </a>
 
   <p class="text-sm text-gray-600 dark:text-gray-200">
-    © 2025 Todos los derechos reservados.
+    © 2026 Todos los derechos reservados.
   </p>
 </footer>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -14,17 +14,20 @@ import Socials from './Socials.astro';
     />
   </div>
 
-  <!-- Call for Papers -->
   <a
     href="devfest2025.gdgaranjuez.com"
     target="_blank"
     rel="noopener noreferrer"
     class="mb-3 block text-center"
   >
-    Devfest2025
+    Devfest 2025
   </a>
-  <a
-    href="https://sessionize.com/devfest-aranjuez-2025/"
+  
+  <!--todo: LINK TO BE UPDATED 
+  https://sessionize.com/devfest-aranjuez-2025/
+  -->
+   <a
+    href=""
     target="_blank"
     rel="noopener noreferrer"
     class="mb-3 block text-center"

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -22,11 +22,11 @@ import Socials from './Socials.astro';
   >
     Devfest 2025
   </a>
-  
+
   <!--todo: LINK TO BE UPDATED 
   https://sessionize.com/devfest-aranjuez-2025/
   -->
-   <a
+  <a
     href=""
     target="_blank"
     rel="noopener noreferrer"
@@ -42,8 +42,9 @@ import Socials from './Socials.astro';
   >
     Código de Conducta
   </a>
-
+  
   <p class="text-sm text-gray-600 dark:text-gray-200">
     © 2026 Todos los derechos reservados.
   </p>
+
 </footer>


### PR DESCRIPTION
updated year: 2026 > 2026
updated: https://sessionize.com/devfest-aranjuez-2026/
updated: 2024 gdg website link with: devfest2025.gdgaranjuez.com