### PR TITLE
feat: update site branding to DevFest 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌟 WEB GDG ARANJUEZ [![GitHub Pages](https://img.shields.io/github/deployments/AdoptaUnJuniorPlatform/GDGAranjuez/github-pages?label=gh-pages&logo=github)](https://devfest2025.gdgaranjuez.com/) ![Deploy status](https://github.com/AdoptaUnJuniorPlatform/GDGAranjuez/actions/workflows/deploy.yml/badge.svg)
+# 🌟 WEB GDG ARANJUEZ [![GitHub Pages](https://img.shields.io/github/deployments/AdoptaUnJuniorPlatform/GDGAranjuez/github-pages?label=gh-pages&logo=github)](https://devfest2026.gdg-aranjuez.com/) ![Deploy status](https://github.com/AdoptaUnJuniorPlatform/GDGAranjuez/actions/workflows/deploy.yml/badge.svg)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Astro](https://img.shields.io/badge/Astro-5.8.1-FF5D01?logo=astro)](https://astro.build)
@@ -7,7 +7,7 @@
 [![ESLint](https://img.shields.io/badge/ESLint-9.27.0-4B32C3?logo=eslint)](https://eslint.org/)
 [![Prettier](https://img.shields.io/badge/Prettier-3.5.3-F7B93E?logo=prettier)](https://prettier.io/)
 
-> Sitio web oficial del DevFest 2025 organizado por GDG Aranjuez 🚀
+> Sitio web oficial del DevFest 2026 organizado por GDG Aranjuez 🚀
 
 ---
 
@@ -19,14 +19,14 @@ Este proyecto se despliega automáticamente a **GitHub Pages** cada vez que se h
 - No es necesario hacer el build manualmente: se ejecuta solo con cada cambio en `main`.
 
 🔗 Versión en producción:  
-👉 [https://devfest2025.gdgaranjuez.com/](https://devfest2025.gdgaranjuez.com/)
+👉 [https://devfest2026.gdg-aranjuez.com/](https://devfest2026.gdg-aranjuez.com/)
 
 ---
 
 ## 📖 Contexto
 
 GDG Aranjuez es una comunidad tecnológica asentada en Aranjuez, una localidad histórica en el sur de la Comunidad de Madrid.  
-El año pasado se realizó el primer evento grande, el [DevFest 2024](https://devfest-2024-aranjuez.vercel.app/), y este año vuelve para realizar un nuevo evento el 4 de Octubre.
+GDG Aranjuez organiza el DevFest en Aranjuez cada año. Tras las ediciones de [2024](https://devfest-2024-aranjuez.vercel.app/) y [2025](https://devfest2025.gdg-aranjuez.com/), la edición **2026** se celebrará el **3 de octubre**.
 
 ---
 
@@ -100,11 +100,11 @@ GDGAranjuez/
 
 | Elemento                               | Estado             | Comentarios                                                                                                                     |
 | -------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| Despliegue automático                  | ✅ Completado      | Se actualiza con cada cambio en `main`. Enlace: [devfest2025.gdgaranjuez.com](https://devfest2025.gdgaranjuez.com/)             |
+| Despliegue automático                  | ✅ Completado      | Se actualiza con cada cambio en `main`. Enlace: [devfest2026.gdg-aranjuez.com](https://devfest2026.gdg-aranjuez.com/)             |
 | Componentes reutilizables y responsive | ✅ Completado      | Sections like schedule, talks, speakers, organizers and sponsors implemented as reusable components.          |
 | Modo claro / oscuro                    | ✅ Completado      | Toggle funcional con soporte visual completo.                                                                                   |
 | Blog en Markdown                       | ✅ Completado      | Sección de artículos funcional con posts dinámicos.                                                                             |
-| Subdominios y estructura por ediciones | ❎ Parcial         | La edición 2024 está enlazada desde el subdominio 2025. Falta implementar estructura base para futuras ediciones y dominio GDG. |
+| Subdominios y estructura por ediciones | ❎ Parcial         | Las ediciones 2024 y 2025 están enlazadas desde el sitio 2026. Falta implementar estructura base para futuras ediciones y dominio GDG. |
 | Gestión vía CMS                        | ❌ No implementado | Pendiente para una posible versión ampliada del proyecto.                                                                       |
 
 ---

--- a/src/components/HeroSection.astro
+++ b/src/components/HeroSection.astro
@@ -42,7 +42,7 @@ import Countdown from './Countdown.astro';
         bg-gradient-to-r from-blue-700 to-purple-700
         dark:bg-gradient-to-r dark:from-blue-300 dark:to-purple-300"
     >
-      DevFest Aranjuez!
+      DevFest Aranjuez 2026!
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"
@@ -91,7 +91,7 @@ import Countdown from './Countdown.astro';
         transition-all duration-300 hover:cursor-pointer
         flex items-center gap-3
         focus:ring-3 dark:focus:ring-sky-400 focus:ring-offset-4 focus:ring-offset-sky-600 dark:focus:ring-offset-gray-700"
-      onclick="window.open('https://www.eventbrite.com/e/devfest-2025-tickets-1361371561989?aff=oddtdtcreator', '_blank')"
+      onclick="window.open('https://www.eventbrite.com/o/gdg-aranjuez-83358663463', '_blank')"
     >
       <span>ENTRADAS</span>
       <svg

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -80,7 +80,7 @@
         href="/"
         class="text-3xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-blue-600 via-purple-500 to-pink-500 drop-shadow"
       >
-        DevFest 2025
+        DevFest 2026
       </a>
       <div class="flex items-center ml-auto 2xl:hidden">
         <button
@@ -116,7 +116,7 @@
   >
     <li>
       <a
-        href="https://www.eventbrite.com/e/devfest-2025-tickets-1361371561989?aff=oddtdtcreator"
+        href="https://www.eventbrite.com/o/gdg-aranjuez-83358663463"
         target="_blank"
         class="nav-link text-purple-700 dark:text-fuchsia-500 font-bold hover:text-blue-700 dark:hover:text-[#FABD04] transition"
       >

--- a/src/components/Sponsors.astro
+++ b/src/components/Sponsors.astro
@@ -69,7 +69,7 @@ import sponsorsData from '../data/sponsors.json';
         class="mt-16 text-center text-lg text-gray-700 dark:text-indigo-200"
       >
         <p>
-          Gracias a todos nuestros patrocinadores por apoyar Devfest GDG Aranjuez.<br />
+          Gracias a todos nuestros patrocinadores por apoyar DevFest 2026 de GDG Aranjuez.<br />
           ¡Su apoyo impulsa a la comunidad tecnológica!
         </p>
       </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,7 +4,7 @@ import '@/styles/global.css';
 import Footer from '@/components/Footer.astro';
 import Navbar from '@/components/Navbar.astro';
 
-const { title = 'GDG Aranjuez ' } = Astro.props;
+const { title = 'GDG Aranjuez | DevFest 2026' } = Astro.props;
 ---
 
 <!doctype html>

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -15,7 +15,7 @@ const posts: Post[] = (await getCollection('posts'))
   );
 ---
 
-<Layout title="Blog">
+<Layout title="Blog | GDG Aranjuez | DevFest 2026">
   <section class="py-16 rounded-2xl m-10 max-w-4xl mx-auto px-6">
     <div class="text-center mb-12">
       <h1

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,7 +11,7 @@ import SpeakersSection from '@/components/SpeakersSection.astro';
 import Layout from '@/layouts/Layout.astro';
 ---
 
-<Layout title="GDG Aranjuez | DevFest 2025">
+<Layout title="GDG Aranjuez | DevFest 2026">
   <main class="max-w-4xl mx-auto px-6 py-2 md:py-2">
     <!-- Hero Section -->
     <HeroSection />


### PR DESCRIPTION
Align page titles, navbar, hero, sponsors copy, README, and Eventbrite links with the 2026 edition (GDG Aranjuez).

Fixes #120 