### PR TITLE
fix(tickets): add rel noopener noreferrer on buy-tickets links

### DIFF
--- a/src/components/HeroSection.astro
+++ b/src/components/HeroSection.astro
@@ -81,8 +81,11 @@ import Countdown from './Countdown.astro';
   <!-- Buttons div -->
   <div class="flex justify-center flex-wrap mx-8 my-5">
     <!-- Entradas Button -->
-    <button
+    <a
       id="entradas-button"
+      href="https://www.eventbrite.com/o/gdg-aranjuez-83358663463"
+      target="_blank"
+      rel="noopener noreferrer"
       aria-label="Botón para conseguir entradas"
       class="group text-2xl md:text-3xl text-white font-semibold m-3 px-9 py-3
         rounded-full bg-gradient-to-r from-blue-800 to-purple-800
@@ -91,7 +94,6 @@ import Countdown from './Countdown.astro';
         transition-all duration-300 hover:cursor-pointer
         flex items-center gap-3
         focus:ring-3 dark:focus:ring-sky-400 focus:ring-offset-4 focus:ring-offset-sky-600 dark:focus:ring-offset-gray-700"
-      onclick="window.open('https://www.eventbrite.com/o/gdg-aranjuez-83358663463', '_blank')"
     >
       <span>ENTRADAS</span>
       <svg
@@ -121,7 +123,7 @@ import Countdown from './Countdown.astro';
           stroke-linejoin="round"
           stroke-width="2"></path>
       </svg>
-    </button>
+    </a>
     <!-- 
     <!-- Call for Papers Button (hidden)
     <button

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -118,6 +118,7 @@
       <a
         href="https://www.eventbrite.com/o/gdg-aranjuez-83358663463"
         target="_blank"
+        rel="noopener noreferrer"
         class="nav-link text-purple-700 dark:text-fuchsia-500 font-bold hover:text-blue-700 dark:hover:text-[#FABD04] transition"
       >
         ENTRADAS


### PR DESCRIPTION
## Summary

- Add `rel="noopener noreferrer"` to the ENTRADAS link in the navbar.
- Replace the hero ENTRADAS `<button>` that uses `window.open(...)` with an `<a>` element using `target="_blank"` and `rel="noopener noreferrer"`.

## Temporary Eventbrite URL

The event has not been published on Eventbrite yet. To avoid broken links, all ticket purchase CTAs currently point to the GDG Aranjuez Eventbrite organization page:

https://www.eventbrite.com/o/gdg-aranjuez-83358663463

Once the event is published, this URL should be replaced with the event-specific Eventbrite URL in both:

- `Navbar.astro`
- `HeroSection.astro`

Closes #125

## Test Plan

- [ ] Clicking ENTRADAS in the navbar opens the Eventbrite organization page in a new tab.
- [ ] Clicking ENTRADAS in the hero section opens the Eventbrite organization page in a new tab.
- [ ] Verify behavior on both desktop and mobile devices.